### PR TITLE
Filtering can be done by given selection network.

### DIFF
--- a/pynetfilter_conntrack/filter.py
+++ b/pynetfilter_conntrack/filter.py
@@ -8,6 +8,7 @@ class Filter:
         self.reverse = False
         self.sort = "orig_ipv4_src"
         self.drop_networks = None
+        self.select_networks = None
 
     def filterConnection(self, conn):
         # Ignore TCP connection in state TIME_WAIT
@@ -31,6 +32,14 @@ class Filter:
             for network in self.drop_networks:
                 if (ip_src in network) or (ip_dst in network):
                     return False
+
+        # Select only from given networks
+        if self.select_networks:
+            for network in self.select_networks:
+                if (ip_src in network) or (ip_dst in network):
+                    return True
+            return False
+
         return True
 
     def createCNetfilterOptions(self):


### PR DESCRIPTION
This patch allow filter connections by given networks when getting dump. 

i.e.
```
ct = pynetfilter_conntrack.Conntrack()
ft = pynetfilter_conntrack.Filter()
ft.select_networks = [IPy.IP('127.0.0.1')]
    for item in ct.dump_table(filter=ft)[0]:
        item.destroy()
```
